### PR TITLE
install: put fpga bitfiles in /usr/share/uldaq/fpga

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ dist_doc_DATA = README.md
 pkgconfigdir=$(libdir)/pkgconfig
 dist_pkgconfig_DATA=libuldaq.pc
 
-fpgadatadir=/etc/uldaq/fpga
+fpgadatadir=/usr/share/uldaq/fpga
 dist_fpgadata_DATA=fpga/USB_1208HS.rbf\
 fpga/USB_1608G_2.rbf\
 fpga/USB_1608G.rbf\

--- a/src/usb/UsbFpgaDevice.cpp
+++ b/src/usb/UsbFpgaDevice.cpp
@@ -15,7 +15,7 @@
 #include "UsbFpgaDevice.h"
 #include "../utility/UlLock.h"
 
-#define FPGA_FILES_PATH		"/etc/uldaq/fpga/"
+#define FPGA_FILES_PATH		"/usr/share/uldaq/fpga/"
 
 namespace ul
 {


### PR DESCRIPTION
Putting fpga bitfiles in /etc is not appropriate.

/usr/share/uldaq is better across unix platforms. It would be better to
get the hardcoded definition out of src/usb/UsbFpgaDevice.cpp, but
I'm an autotools neophyte, and haven't been able to figure that out.

