### PR TITLE
Fix conversion of UNIPT01VOLTS in examples/utility.h

### DIFF
--- a/examples/utility.h
+++ b/examples/utility.h
@@ -361,7 +361,7 @@ void ConvertRangeToMinMax(Range range, double* min, double* max)
 		break;
 	case(UNIPT01VOLTS):
 		*min = 0.0;
-		*max = 0.1;
+		*max = 0.01;
 		break;
 	case(UNIPT005VOLTS):
 		*min = 0.0;


### PR DESCRIPTION
The `enum` value `UNIPT01VOLTS` means “unipolar, .01 volts”. However, `ConvertRangeToMinMax()` incorrectly translates it to the range 0&nbsp;–&nbsp;.1&nbsp;V.